### PR TITLE
Fix overflow/scrollbars issues

### DIFF
--- a/ts/atproto-tools/package.json
+++ b/ts/atproto-tools/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "format": "prettier --write .",
+    "format": "prettier --write src",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/ts/atproto-tools/src/App.tsx
+++ b/ts/atproto-tools/src/App.tsx
@@ -7,9 +7,9 @@ import {
   useLocation,
 } from "react-router-dom";
 
+import LexiconEditor from "./components/lexicon-editor/LexiconEditor";
 import Records from "./components/records-temp/Records";
 import Welcome from "./components/welcome/Welcome";
-import LexiconEditor from "./components/lexicon-editor/LexiconEditor";
 
 const NavList: React.FC = () => {
   let location = useLocation();
@@ -98,7 +98,7 @@ const router = createBrowserRouter([
         <LexiconEditor />
       </ThemeWrapper>
     ),
-  }
+  },
 ]);
 
 function App() {

--- a/ts/atproto-tools/src/components/lexicon-editor/LexiconEditor.tsx
+++ b/ts/atproto-tools/src/components/lexicon-editor/LexiconEditor.tsx
@@ -1,7 +1,8 @@
-import { Lexicons, jsonStringToLex } from "@atproto/lexicon";
-import { Editor } from "@monaco-editor/react";
 import { FC, useEffect, useState } from "react";
+import { jsonStringToLex, Lexicons } from "@atproto/lexicon";
+import { Editor } from "@monaco-editor/react";
 import { useMediaQuery } from "react-responsive";
+
 import { lexicons } from "../../lexicons.ts";
 import { Badge } from "../catalyst/badge.tsx";
 import { Text } from "../catalyst/text.js";
@@ -15,7 +16,7 @@ lexicons.forEach((lexicon) => {
   if (lexicon.defs.main?.type === "record") {
     knownLexicons.push(lexicon.id);
     if (lexicon.id === "app.bsky.feed.like") {
-      initialLexicon = lexicon
+      initialLexicon = lexicon;
     }
   }
 });
@@ -35,12 +36,9 @@ const LexiconEditor: FC<{}> = () => {
     document.title = "Edit Lexicons";
   }, []);
 
-
   return (
-    <div className="flex min-h-0 min-w-0 grow flex-col gap-4 pb-4 pt-0 px-8 lg:h-dvh lg:flex-row">
-      <div
-        className="flex min-h-0 grow flex-col gap-2 lg:basis-0 dark:[color-scheme:dark]"
-      >
+    <div className="flex min-h-0 min-w-0 grow flex-col gap-4 px-8 pb-4 pt-0 lg:h-dvh lg:flex-row">
+      <div className="flex min-h-0 grow flex-col gap-2 lg:basis-0 dark:[color-scheme:dark]">
         <LexEditor
           activeLexPair={activeLexPair}
           setActiveLexPair={setActiveLexPair}
@@ -60,7 +58,8 @@ interface LexEditorProps {
 
 function LexEditor({ activeLexPair, setActiveLexPair }: LexEditorProps) {
   const [pendingLex, setPendingLex] = useState<string>(activeLexPair.lexRaw);
-  const [lexValidationResult, setLexValidationResult] = useState<string>("Lexicon is Empty");
+  const [lexValidationResult, setLexValidationResult] =
+    useState<string>("Lexicon is Empty");
 
   const darkMode = useMediaQuery({
     query: "(prefers-color-scheme: dark)",
@@ -79,7 +78,7 @@ function LexEditor({ activeLexPair, setActiveLexPair }: LexEditorProps) {
       asLex = jsonStringToLex(raw);
       try {
         lex.remove(asLex.id);
-      } catch { }
+      } catch {}
       lex.add(asLex);
     } catch (e) {
       console.log("Lexicon is Invalid:", e);
@@ -93,9 +92,7 @@ function LexEditor({ activeLexPair, setActiveLexPair }: LexEditorProps) {
   function getBadgeColor(result: string): "green" | "yellow" | "red" {
     if (result === "Lexicon is Valid") {
       return "green";
-    } else if (
-      result === "Lexicon is Empty"
-    ) {
+    } else if (result === "Lexicon is Empty") {
       return "yellow";
     } else {
       return "red";
@@ -109,9 +106,7 @@ function LexEditor({ activeLexPair, setActiveLexPair }: LexEditorProps) {
   return (
     <div className="flex min-h-0 grow flex-col pt-12 lg:basis-0">
       <Text className="mb-4 text-center">
-        <span className="text-3xl dark:text-slate-100">
-          Build a Lexicon
-        </span>
+        <span className="text-3xl dark:text-slate-100">Build a Lexicon</span>
       </Text>
       <div className="h-96 grow lg:h-auto">
         <Editor
@@ -133,10 +128,10 @@ function LexEditor({ activeLexPair, setActiveLexPair }: LexEditorProps) {
         />
       </div>
       <div className="mt-2">
-        <Badge color={getBadgeColor(lexValidationResult)}>{lexValidationResult}</Badge>
+        <Badge color={getBadgeColor(lexValidationResult)}>
+          {lexValidationResult}
+        </Badge>
       </div>
     </div>
-  )
+  );
 }
-
-

--- a/ts/atproto-tools/src/components/lexicon-editor/RecordEditor.tsx
+++ b/ts/atproto-tools/src/components/lexicon-editor/RecordEditor.tsx
@@ -1,7 +1,13 @@
-import { jsonStringToLex, jsonToLex, Lexicons, ValidationError } from "@atproto/lexicon";
-import Editor from "@monaco-editor/react";
 import { useEffect, useState } from "react";
+import {
+  jsonStringToLex,
+  jsonToLex,
+  Lexicons,
+  ValidationError,
+} from "@atproto/lexicon";
+import Editor from "@monaco-editor/react";
 import { useMediaQuery } from "react-responsive";
+
 import { lexicons } from "../../lexicons.js";
 import { Badge } from "../catalyst/badge.js";
 import { Text } from "../catalyst/text.js";
@@ -27,7 +33,8 @@ function RecordEditor({ lexID, lexRaw }: RecordEditorProps) {
       "uri": "at://did:plc:umdwh4r456zres7qrdbfpibd/app.bsky.feed.post/3kmlyenrxdh27"
     }
   }`);
-  const [lexValidationResult, setLexValidationResult] = useState<string>("Record is Empty");
+  const [lexValidationResult, setLexValidationResult] =
+    useState<string>("Record is Empty");
 
   const darkMode = useMediaQuery({
     query: "(prefers-color-scheme: dark)",
@@ -36,7 +43,7 @@ function RecordEditor({ lexID, lexRaw }: RecordEditorProps) {
   try {
     // Remove the lexicon if it's already registered
     lex.remove(lexID);
-  } catch (e) { }
+  } catch (e) {}
 
   // Register our custom lexicon
   lex.add(jsonStringToLex(lexRaw));
@@ -80,9 +87,7 @@ function RecordEditor({ lexID, lexRaw }: RecordEditorProps) {
   return (
     <div className="flex min-h-0 grow flex-col pt-12 lg:basis-0">
       <Text className="mb-4 text-center">
-        <span className="text-3xl dark:text-slate-100">
-          Validate a Record
-        </span>
+        <span className="text-3xl dark:text-slate-100">Validate a Record</span>
       </Text>
 
       <div className="h-96 grow lg:h-auto">
@@ -97,12 +102,16 @@ function RecordEditor({ lexID, lexRaw }: RecordEditorProps) {
             wordWrap: "on",
             lineNumbersMinChars: 3,
           }}
-          onChange={(value) => { if (value) setRecord(value) }}
+          onChange={(value) => {
+            if (value) setRecord(value);
+          }}
         />
       </div>
 
       <div className="mt-2">
-        <Badge color={getBadgeColor(lexValidationResult)}>{lexValidationResult}</Badge>
+        <Badge color={getBadgeColor(lexValidationResult)}>
+          {lexValidationResult}
+        </Badge>
       </div>
     </div>
   );

--- a/ts/atproto-tools/src/components/records-temp/RawRecord.tsx
+++ b/ts/atproto-tools/src/components/records-temp/RawRecord.tsx
@@ -1,8 +1,9 @@
-import { JSONRecord } from "../../models/Record";
-import { Lexicons, ValidationError, jsonToLex } from "@atproto/lexicon";
-import { lexicons } from "../../lexicons.ts";
-import { Badge } from "../catalyst/badge.tsx";
+import { jsonToLex, Lexicons, ValidationError } from "@atproto/lexicon";
 import Editor from "@monaco-editor/react";
+
+import { lexicons } from "../../lexicons.ts";
+import { JSONRecord } from "../../models/Record";
+import { Badge } from "../catalyst/badge.tsx";
 import { Text } from "../catalyst/text.tsx";
 
 const lex = new Lexicons();
@@ -76,17 +77,17 @@ function RawRecord({ record }: RawRecordProps) {
   if (numLines > 25) numLines = 25;
 
   return (
-    <div className="flex grow flex-col min-w-0 min-h-0 pt-12 lg:basis-0">
+    <div className="flex min-h-0 min-w-0 grow flex-col pt-12 lg:basis-0">
       <Text className="mb-2">
         {record.collection !== "" ? (
           <>
             Raw record content for:{" "}
-            <span className="text-sm font-mono break-all">
+            <span className="break-all font-mono text-sm">
               at://{record.repo}/{record.collection}/{record.rkey}
             </span>
           </>
         ) : (
-          <span className="text-sm font-mono break-all">
+          <span className="break-all font-mono text-sm">
             No record selected
           </span>
         )}
@@ -96,7 +97,7 @@ function RawRecord({ record }: RawRecordProps) {
         <Badge color={badgeColor}>{lexValidationResult}</Badge>
       </div>
 
-      <div className="grow h-96 lg:h-auto">
+      <div className="h-96 grow lg:h-auto">
         <Editor
           width="100%"
           height="100%"

--- a/ts/atproto-tools/src/components/records-temp/RawRecord.tsx
+++ b/ts/atproto-tools/src/components/records-temp/RawRecord.tsx
@@ -1,98 +1,113 @@
-import { JSONRecord } from '../../models/Record'
-import { Lexicons, ValidationError, jsonToLex } from '@atproto/lexicon';
-import { lexicons } from '../../lexicons.ts';
-import { Badge } from '../catalyst/badge.tsx';
-import Editor from '@monaco-editor/react';
-import { Text } from '../catalyst/text.tsx';
+import { JSONRecord } from "../../models/Record";
+import { Lexicons, ValidationError, jsonToLex } from "@atproto/lexicon";
+import { lexicons } from "../../lexicons.ts";
+import { Badge } from "../catalyst/badge.tsx";
+import Editor from "@monaco-editor/react";
+import { Text } from "../catalyst/text.tsx";
 
-const lex = new Lexicons()
-const knownLexicons: string[] = []
+const lex = new Lexicons();
+const knownLexicons: string[] = [];
 lexicons.forEach((lexicon) => {
-    if (lexicon.defs.main?.type === 'record') {
-        // @ts-ignore
-        lex.add(lexicon)
-        knownLexicons.push(lexicon.id)
-    }
-})
-
+  if (lexicon.defs.main?.type === "record") {
+    // @ts-expect-error - we know this is a record
+    lex.add(lexicon);
+    knownLexicons.push(lexicon.id);
+  }
+});
 
 interface RawRecordProps {
-    record: JSONRecord
+  record: JSONRecord;
 }
 
 function RawRecord({ record }: RawRecordProps) {
-    function validateLexicon(collection: string, raw: any): string {
-        if (!knownLexicons.includes(collection)) {
-            return 'Unknown Collection'
-        }
-
-        if (Object.keys(raw).length === 0) {
-            return 'Record is Empty'
-        }
-
-        try {
-            lex.assertValidRecord(collection, jsonToLex(raw))
-        } catch (e) {
-            if (e instanceof ValidationError) {
-                console.log(e);
-                return e.message
-            }
-        }
-        return 'Record is Valid'
+  function validateLexicon(collection: string, raw: any): string {
+    if (!knownLexicons.includes(collection)) {
+      return "Unknown Collection";
     }
 
-    function getBadgeColor(result: string): "green" | "yellow" | "red" {
-        if (result === 'Record is Valid') {
-            return 'green'
-        } else if (result === 'Unknown Collection' || result === 'Record is Empty') {
-            return 'yellow'
-        } else {
-            return 'red'
-        }
+    if (Object.keys(raw).length === 0) {
+      return "Record is Empty";
     }
 
-    if (!record) {
-        record = { repo: '', collection: '', rkey: '', seq: 0, action: '', raw: {} }
+    try {
+      lex.assertValidRecord(collection, jsonToLex(raw));
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        console.log(e);
+        return e.message;
+      }
     }
-    if (!record.raw) {
-        record.raw = {}
+    return "Record is Valid";
+  }
+
+  function getBadgeColor(result: string): "green" | "yellow" | "red" {
+    if (result === "Record is Valid") {
+      return "green";
+    } else if (
+      result === "Unknown Collection" ||
+      result === "Record is Empty"
+    ) {
+      return "yellow";
+    } else {
+      return "red";
     }
+  }
 
-    const lexValidationResult = validateLexicon(record.collection, record.raw)
-    const badgeColor = getBadgeColor(lexValidationResult)
+  if (!record) {
+    record = {
+      repo: "",
+      collection: "",
+      rkey: "",
+      seq: 0,
+      action: "",
+      raw: {},
+    };
+  }
+  if (!record.raw) {
+    record.raw = {};
+  }
 
-    const formattedRaw = JSON.stringify(record.raw, null, 2)
-    let numLines = formattedRaw.split('\n').length
-    if (numLines < 5) numLines = 5
-    if (numLines > 25) numLines = 25
+  const lexValidationResult = validateLexicon(record.collection, record.raw);
+  const badgeColor = getBadgeColor(lexValidationResult);
 
-    return (
-        <div className='flex grow flex-col min-h-0 pt-12 lg:basis-0'>
-            <Text className="mb-2">
-                {record.collection !== "" ? (<>
-                    Raw record content for: <span className="text-sm font-mono break-all">at://{record.repo}/{record.collection}/{record.rkey}</span>
-                </>
-                ) : (
-                    <span className="text-sm font-mono break-all">No record selected</span>
-                )}
-            </Text>
+  const formattedRaw = JSON.stringify(record.raw, null, 2);
+  let numLines = formattedRaw.split("\n").length;
+  if (numLines < 5) numLines = 5;
+  if (numLines > 25) numLines = 25;
 
-            <div className='grow h-96 lg:h-auto'>
-                <Editor
-                    width="100%"
-                    height="100%"
-                    language="json"
-                    theme="vs-dark"
-                    value={formattedRaw}
-                    options={{ readOnly: true, wordWrap: 'on', lineNumbersMinChars: 3 }}
-                />
-            </div>
+  return (
+    <div className="flex grow flex-col min-w-0 min-h-0 pt-12 lg:basis-0">
+      <Text className="mb-2">
+        {record.collection !== "" ? (
+          <>
+            Raw record content for:{" "}
+            <span className="text-sm font-mono break-all">
+              at://{record.repo}/{record.collection}/{record.rkey}
+            </span>
+          </>
+        ) : (
+          <span className="text-sm font-mono break-all">
+            No record selected
+          </span>
+        )}
+      </Text>
 
-            <div className="mt-2">
-                <Badge color={badgeColor}>{lexValidationResult}</Badge>
-            </div>
-        </div>
-    )
+      <div className="mb-2">
+        <Badge color={badgeColor}>{lexValidationResult}</Badge>
+      </div>
+
+      <div className="grow h-96 lg:h-auto">
+        <Editor
+          width="100%"
+          height="100%"
+          language="json"
+          theme="vs-dark"
+          value={formattedRaw}
+          options={{ readOnly: true, wordWrap: "on", lineNumbersMinChars: 3 }}
+        />
+      </div>
+    </div>
+  );
 }
 
-export default RawRecord
+export default RawRecord;

--- a/ts/atproto-tools/src/components/records-temp/Records.tsx
+++ b/ts/atproto-tools/src/components/records-temp/Records.tsx
@@ -106,7 +106,7 @@ const Records: FC<{}> = () => {
                     setSearchParams={setSearchParams}
                 />}
 
-                <div className="min-h-0 h-96 lg:h-auto grow overflow-y-auto">
+                <div className="min-h-0 h-96 lg:h-auto grow overflow-y-auto lg:overflow-x-hidden">
                     <RecordsTable records={records} setSelectedRecord={setSelectedRecord} selectedRecord={selectedRecord} />
                 </div>
             </div>

--- a/ts/atproto-tools/src/components/records-temp/Records.tsx
+++ b/ts/atproto-tools/src/components/records-temp/Records.tsx
@@ -1,307 +1,420 @@
 import { FC, useEffect, useState } from "react";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../catalyst/table'
-import { JSONRecord } from '../../models/Record'
-import { LOOKING_GLASS_HOST } from "../../constants";
-import { Button } from "../catalyst/button";
-import RawRecord from "./RawRecord";
 import { useSearchParams } from "react-router-dom";
+
+import { LOOKING_GLASS_HOST } from "../../constants";
+import { JSONRecord } from "../../models/Record";
+import { Button } from "../catalyst/button";
 import { Field, FieldGroup, Fieldset, Label } from "../catalyst/fieldset";
 import { Input } from "../catalyst/input";
-
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../catalyst/table";
+import RawRecord from "./RawRecord";
 
 const Records: FC = () => {
-    const [selectedRecord, setSelectedRecord] = useState<JSONRecord | null>(null);
-    const [records, setRecords] = useState<JSONRecord[]>([]);
-    const [error, setError] = useState<string | null>(null);
-    const [hasFetched, setHasFetched] = useState(false);
+  const [selectedRecord, setSelectedRecord] = useState<JSONRecord | null>(null);
+  const [records, setRecords] = useState<JSONRecord[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [hasFetched, setHasFetched] = useState(false);
 
-    const [didQuery, setDIDQuery] = useState<string | null>(null);
-    const [collectionQuery, setCollectionQuery] = useState<string | null>(null);
-    const [rkeyQuery, setRKeyQuery] = useState<string | null>(null);
-    const [seqQuery, setSeqQuery] = useState<string | null>(null);
+  const [didQuery, setDIDQuery] = useState<string | null>(null);
+  const [collectionQuery, setCollectionQuery] = useState<string | null>(null);
+  const [rkeyQuery, setRKeyQuery] = useState<string | null>(null);
+  const [seqQuery, setSeqQuery] = useState<string | null>(null);
 
-    const [queryInitialized, setQueryInitialized] = useState(false);
+  const [queryInitialized, setQueryInitialized] = useState(false);
 
-    const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
 
-    useEffect(() => {
-        document.title = "View Firehose Records";
-    }, []);
+  useEffect(() => {
+    document.title = "View Firehose Records";
+  }, []);
 
-    const fetchRecords = () => {
-        const url = new URL(`${LOOKING_GLASS_HOST}/records`);
-        if (didQuery) {
-            url.searchParams.append("did", didQuery);
-        }
-        if (collectionQuery) {
-            url.searchParams.append("collection", collectionQuery);
-        }
-        if (rkeyQuery) {
-            url.searchParams.append("rkey", rkeyQuery);
-        }
-        if (seqQuery) {
-            url.searchParams.append("seq", seqQuery);
-        }
-        fetch(url.toString())
-            .then((response) => response.json())
-            .then((data) => {
-                if (data.error) {
-                    setError(data.error);
-                } else {
-                    const newRecords = data.records.map((record: JSONRecord) => {
-                        record.key = `${record.seq}_${record.collection}_${record.rkey}`;
-                        return record;
-                    })
-                    let firstRecord = null;
-                    for (const record of newRecords) {
-                        if (record.raw) {
-                            firstRecord = record;
-                            break;
-                        }
-                    }
-                    setRecords(newRecords);
-                    setSelectedRecord(firstRecord);
-                }
-            })
-            .finally(() => setHasFetched(true));
-    };
-
-    useEffect(() => {
-        // Wait until all query params are set before fetching records
-        if (queryInitialized) {
-            fetchRecords();
-        }
-    }, [didQuery, collectionQuery, rkeyQuery, seqQuery, queryInitialized]);
-
-    useEffect(() => {
-        searchParams.has("did") ? setDIDQuery(searchParams.get("did")!) : setDIDQuery(null);
-        searchParams.has("collection") ? setCollectionQuery(searchParams.get("collection")!) : setCollectionQuery(null);
-        searchParams.has("rkey") ? setRKeyQuery(searchParams.get("rkey")!) : setRKeyQuery(null);
-        searchParams.has("seq") ? setSeqQuery(searchParams.get("seq")!) : setSeqQuery(null);
-
-        if (searchParams.has("uri")) {
-            // Parse out the AT URI and set the query params
-            const uri = searchParams.get("uri")!;
-            if (uri.startsWith("at://")) {
-                const uriParts = uri.split("/");
-                const did = uriParts[2];
-                const collection = uriParts[3];
-                const rkey = uriParts[4];
-                setDIDQuery(did);
-                setCollectionQuery(collection);
-                setRKeyQuery(rkey);
+  const fetchRecords = () => {
+    const url = new URL(`${LOOKING_GLASS_HOST}/records`);
+    if (didQuery) {
+      url.searchParams.append("did", didQuery);
+    }
+    if (collectionQuery) {
+      url.searchParams.append("collection", collectionQuery);
+    }
+    if (rkeyQuery) {
+      url.searchParams.append("rkey", rkeyQuery);
+    }
+    if (seqQuery) {
+      url.searchParams.append("seq", seqQuery);
+    }
+    fetch(url.toString())
+      .then((response) => response.json())
+      .then((data) => {
+        if (data.error) {
+          setError(data.error);
+        } else {
+          const newRecords = data.records.map((record: JSONRecord) => {
+            record.key = `${record.seq}_${record.collection}_${record.rkey}`;
+            return record;
+          });
+          let firstRecord = null;
+          for (const record of newRecords) {
+            if (record.raw) {
+              firstRecord = record;
+              break;
             }
+          }
+          setRecords(newRecords);
+          setSelectedRecord(firstRecord);
         }
+      })
+      .finally(() => setHasFetched(true));
+  };
 
-        setQueryInitialized(true);
-    }, [searchParams]);
+  useEffect(() => {
+    // Wait until all query params are set before fetching records
+    if (queryInitialized) {
+      fetchRecords();
+    }
+  }, [didQuery, collectionQuery, rkeyQuery, seqQuery, queryInitialized]);
 
-    return (
-        <div className="flex flex-col lg:flex-row min-w-0 min-h-0 gap-6 grow p-4 pt-6 lg:h-dvh">
-            <div className='flex-col grow min-h-0 flex gap-2 lg:basis-0' style={{ colorScheme: "dark" }}>
-                <h1 className="text-4xl font-bold">View Firehose Records</h1>
-                {queryInitialized && <SearchForm
-                    didQuery={didQuery}
-                    collectionQuery={collectionQuery}
-                    rkeyQuery={rkeyQuery}
-                    seqQuery={seqQuery}
-                    setSearchParams={setSearchParams}
-                />}
+  useEffect(() => {
+    searchParams.has("did")
+      ? setDIDQuery(searchParams.get("did")!)
+      : setDIDQuery(null);
+    searchParams.has("collection")
+      ? setCollectionQuery(searchParams.get("collection")!)
+      : setCollectionQuery(null);
+    searchParams.has("rkey")
+      ? setRKeyQuery(searchParams.get("rkey")!)
+      : setRKeyQuery(null);
+    searchParams.has("seq")
+      ? setSeqQuery(searchParams.get("seq")!)
+      : setSeqQuery(null);
 
-                <div className="min-h-0 h-96 lg:h-auto grow overflow-y-auto lg:overflow-x-hidden">
-                    <RecordsTable records={records} setSelectedRecord={setSelectedRecord} selectedRecord={selectedRecord} />
-                </div>
-            </div>
-            <RawRecord record={selectedRecord!} key={hasFetched ? "a" : "b"} />
-        </div>
-    )
-};
-
-function RecordsTable({ records, selectedRecord, setSelectedRecord }: {
-    records: JSONRecord[],
-    selectedRecord: JSONRecord | null,
-    setSelectedRecord: (record: JSONRecord) => void,
-}) {
-    return (
-        <Table
-            striped dense grid sticky
-            className="mx-0 focus:outline-none [--gutter:theme(spacing.2)] sm:[--gutter:theme(spacing.2)]"
-            tabIndex={0}
-            onKeyDown={(e) => {
-                e.preventDefault();
-                if (e.key === "ArrowDown" && selectedRecord) {
-                    const index = records.findIndex((record) => record.key === selectedRecord?.key);
-                    if (index < records.length - 1) {
-                        setSelectedRecord(records[index + 1]);
-                        // Scroll to the selected record
-                        if (selectedRecord.key) {
-                            const selectedRecordElement = document.getElementById(selectedRecord.key);
-                            if (selectedRecordElement) {
-                                selectedRecordElement.scrollIntoView({ block: "nearest" });
-                            }
-                        }
-                    }
-                }
-                if (e.key === "ArrowUp" && selectedRecord) {
-                    const index = records.findIndex((record) => record.key === selectedRecord?.key);
-                    if (index > 0) {
-                        setSelectedRecord(records[index - 1]);
-                        // Scroll to the selected record
-                        if (selectedRecord.key) {
-                            const selectedRecordElement = document.getElementById(selectedRecord.key);
-                            if (selectedRecordElement) {
-                                selectedRecordElement.scrollIntoView({ block: "nearest" });
-                            }
-                        }
-                    }
-                }
-            }
-            }
-        >
-            <TableHead>
-                <TableRow>
-                    <TableHeader>Seq</TableHeader>
-                    <TableHeader>Repo</TableHeader>
-                    <TableHeader>Collection</TableHeader>
-                    <TableHeader>Record Key</TableHeader>
-                    <TableHeader>Action</TableHeader>
-                </TableRow>
-            </TableHead>
-            <TableBody>
-                {records.map((record) => (
-                    <TableRow
-                        key={record?.key || ""}
-                        id={record?.key || ""}
-                        className={(selectedRecord?.key === record?.key ? "!bg-white/[15%] " : "") + " scroll-m-36"}
-                        onClick={() => setSelectedRecord(record)}
-                    >
-                        <TableCell className="font-mono text-zinc-400">
-                            <Tooltip text={record.pds || ""} position="right">
-                                <span>{record.seq}</span>
-                            </Tooltip>
-                        </TableCell>
-                        <TableCell className="font-mono">
-                            <Tooltip text={record.handle || ""} position="top">
-                                <span>{record.repo}</span>
-                            </Tooltip>
-                        </TableCell>
-                        <TableCell className="text-zinc-400" >{record.collection}</TableCell>
-                        <TableCell className="font-mono" >{record.rkey}</TableCell>
-                        <TableCell className="text-zinc-400" >{record.action}</TableCell>
-                    </TableRow>
-                ))}
-            </TableBody>
-        </Table>
-    )
-}
-
-function SearchForm({ didQuery, collectionQuery, rkeyQuery, seqQuery, setSearchParams }: {
-    didQuery: string | null,
-    collectionQuery: string | null,
-    rkeyQuery: string | null,
-    seqQuery: string | null,
-    setSearchParams: (searchParams: URLSearchParams) => void,
-}) {
-    const [didSearch, setDIDSearch] = useState<string | null>(didQuery);
-    const [collectionSearch, setCollectionSearch] = useState<string | null>(collectionQuery);
-    const [rkeySearch, setRKeySearch] = useState<string | null>(rkeyQuery);
-    const [seqSearch, setSeqSearch] = useState<string | null>(seqQuery);
-
-    const handleSearch = () => {
-        const searchParams = new URLSearchParams();
-        if (didSearch) {
-            searchParams.append("did", didSearch);
-        }
-        if (collectionSearch) {
-            searchParams.append("collection", collectionSearch);
-        }
-        if (rkeySearch) {
-            searchParams.append("rkey", rkeySearch);
-        }
-        if (seqSearch) {
-            searchParams.append("seq", seqSearch);
-        }
-        setSearchParams(searchParams);
+    if (searchParams.has("uri")) {
+      // Parse out the AT URI and set the query params
+      const uri = searchParams.get("uri")!;
+      if (uri.startsWith("at://")) {
+        const uriParts = uri.split("/");
+        const did = uriParts[2];
+        const collection = uriParts[3];
+        const rkey = uriParts[4];
+        setDIDQuery(did);
+        setCollectionQuery(collection);
+        setRKeyQuery(rkey);
+      }
     }
 
+    setQueryInitialized(true);
+  }, [searchParams]);
 
-    return (
-        <form onSubmit={(e) => {
-            e.preventDefault();
-            handleSearch();
-        }}>
-            <Fieldset className="mb-4">
-                <FieldGroup>
-                    <div className="grid grid-cols-1 gap-8 sm:grid-cols-9 sm:gap-4">
-                        <Field className="col-span-1">
-                            <Label>Seq</Label>
-                            <Input name="seq" value={seqSearch || ""} onChange={(e) => setSeqSearch(e.target.value.trim())} />
-                        </Field>
-                        <Field className="col-span-3">
-                            <Label>DID</Label>
-                            <Input name="did" value={didSearch || ""} onChange={(e) => setDIDSearch(e.target.value.trim())} />
-                        </Field>
-                        <Field className="col-span-2">
-                            <Label>Collection</Label>
-                            <Input
-                                name="collection"
-                                value={collectionSearch || ""}
-                                onChange={(e) => setCollectionSearch(e.target.value.trim())}
-                                disabled={didSearch === null || didSearch === ""}
-                            />
-                        </Field>
-                        <Field className="col-span-2">
-                            <Label>Record Key</Label>
-                            <Input
-                                name="rkey"
-                                value={rkeySearch || ""}
-                                onChange={(e) => setRKeySearch(e.target.value.trim())}
-                                disabled={(didSearch === null || didSearch === "") || (collectionSearch === null || collectionSearch === "")}
-                            />
-                        </Field>
+  return (
+    <div className="flex min-h-0 min-w-0 grow flex-col gap-6 p-4 pt-6 lg:h-dvh lg:flex-row">
+      <div
+        className="flex min-h-0 grow flex-col gap-2 lg:basis-0"
+        style={{ colorScheme: "dark" }}
+      >
+        <h1 className="text-4xl font-bold">View Firehose Records</h1>
+        {queryInitialized && (
+          <SearchForm
+            didQuery={didQuery}
+            collectionQuery={collectionQuery}
+            rkeyQuery={rkeyQuery}
+            seqQuery={seqQuery}
+            setSearchParams={setSearchParams}
+          />
+        )}
 
-                        <div className="justify-self-end mt-auto">
-                            <Button onClick={handleSearch} type="submit">
-                                Search
-                            </Button>
-                        </div>
-                    </div>
-                </FieldGroup>
-            </Fieldset>
-        </form>
-    )
+        <div className="h-96 min-h-0 grow overflow-y-auto lg:h-auto lg:overflow-x-hidden">
+          <RecordsTable
+            records={records}
+            setSelectedRecord={setSelectedRecord}
+            selectedRecord={selectedRecord}
+          />
+        </div>
+      </div>
+      <RawRecord record={selectedRecord!} key={hasFetched ? "a" : "b"} />
+    </div>
+  );
+};
+
+function RecordsTable({
+  records,
+  selectedRecord,
+  setSelectedRecord,
+}: {
+  records: JSONRecord[];
+  selectedRecord: JSONRecord | null;
+  setSelectedRecord: (record: JSONRecord) => void;
+}) {
+  return (
+    <Table
+      striped
+      dense
+      grid
+      sticky
+      className="mx-0 [--gutter:theme(spacing.2)] focus:outline-none sm:[--gutter:theme(spacing.2)]"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        e.preventDefault();
+        if (e.key === "ArrowDown" && selectedRecord) {
+          const index = records.findIndex(
+            (record) => record.key === selectedRecord?.key,
+          );
+          if (index < records.length - 1) {
+            setSelectedRecord(records[index + 1]);
+            // Scroll to the selected record
+            if (selectedRecord.key) {
+              const selectedRecordElement = document.getElementById(
+                selectedRecord.key,
+              );
+              if (selectedRecordElement) {
+                selectedRecordElement.scrollIntoView({ block: "nearest" });
+              }
+            }
+          }
+        }
+        if (e.key === "ArrowUp" && selectedRecord) {
+          const index = records.findIndex(
+            (record) => record.key === selectedRecord?.key,
+          );
+          if (index > 0) {
+            setSelectedRecord(records[index - 1]);
+            // Scroll to the selected record
+            if (selectedRecord.key) {
+              const selectedRecordElement = document.getElementById(
+                selectedRecord.key,
+              );
+              if (selectedRecordElement) {
+                selectedRecordElement.scrollIntoView({ block: "nearest" });
+              }
+            }
+          }
+        }
+      }}
+    >
+      <TableHead>
+        <TableRow>
+          <TableHeader>Seq</TableHeader>
+          <TableHeader>Repo</TableHeader>
+          <TableHeader>Collection</TableHeader>
+          <TableHeader>Record Key</TableHeader>
+          <TableHeader>Action</TableHeader>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {records.map((record) => (
+          <TableRow
+            key={record?.key || ""}
+            id={record?.key || ""}
+            className={
+              (selectedRecord?.key === record?.key ? "!bg-white/[15%] " : "") +
+              " scroll-m-36"
+            }
+            onClick={() => setSelectedRecord(record)}
+          >
+            <TableCell className="font-mono text-zinc-400">
+              <Tooltip text={record.pds || ""} position="right">
+                <span>{record.seq}</span>
+              </Tooltip>
+            </TableCell>
+            <TableCell className="font-mono">
+              <Tooltip text={record.handle || ""} position="top">
+                <span>{record.repo}</span>
+              </Tooltip>
+            </TableCell>
+            <TableCell className="text-zinc-400">{record.collection}</TableCell>
+            <TableCell className="font-mono">{record.rkey}</TableCell>
+            <TableCell className="text-zinc-400">{record.action}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function SearchForm({
+  didQuery,
+  collectionQuery,
+  rkeyQuery,
+  seqQuery,
+  setSearchParams,
+}: {
+  didQuery: string | null;
+  collectionQuery: string | null;
+  rkeyQuery: string | null;
+  seqQuery: string | null;
+  setSearchParams: (searchParams: URLSearchParams) => void;
+}) {
+  const [didSearch, setDIDSearch] = useState<string | null>(didQuery);
+  const [collectionSearch, setCollectionSearch] = useState<string | null>(
+    collectionQuery,
+  );
+  const [rkeySearch, setRKeySearch] = useState<string | null>(rkeyQuery);
+  const [seqSearch, setSeqSearch] = useState<string | null>(seqQuery);
+
+  const handleSearch = () => {
+    const searchParams = new URLSearchParams();
+    if (didSearch) {
+      searchParams.append("did", didSearch);
+    }
+    if (collectionSearch) {
+      searchParams.append("collection", collectionSearch);
+    }
+    if (rkeySearch) {
+      searchParams.append("rkey", rkeySearch);
+    }
+    if (seqSearch) {
+      searchParams.append("seq", seqSearch);
+    }
+    setSearchParams(searchParams);
+  };
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleSearch();
+      }}
+    >
+      <Fieldset className="mb-4">
+        <FieldGroup>
+          <div className="grid grid-cols-1 gap-8 sm:grid-cols-9 sm:gap-4">
+            <Field className="col-span-1">
+              <Label>Seq</Label>
+              <Input
+                name="seq"
+                value={seqSearch || ""}
+                onChange={(e) => setSeqSearch(e.target.value.trim())}
+              />
+            </Field>
+            <Field className="col-span-3">
+              <Label>DID</Label>
+              <Input
+                name="did"
+                value={didSearch || ""}
+                onChange={(e) => setDIDSearch(e.target.value.trim())}
+              />
+            </Field>
+            <Field className="col-span-2">
+              <Label>Collection</Label>
+              <Input
+                name="collection"
+                value={collectionSearch || ""}
+                onChange={(e) => setCollectionSearch(e.target.value.trim())}
+                disabled={didSearch === null || didSearch === ""}
+              />
+            </Field>
+            <Field className="col-span-2">
+              <Label>Record Key</Label>
+              <Input
+                name="rkey"
+                value={rkeySearch || ""}
+                onChange={(e) => setRKeySearch(e.target.value.trim())}
+                disabled={
+                  didSearch === null ||
+                  didSearch === "" ||
+                  collectionSearch === null ||
+                  collectionSearch === ""
+                }
+              />
+            </Field>
+
+            <div className="mt-auto justify-self-end">
+              <Button onClick={handleSearch} type="submit">
+                Search
+              </Button>
+            </div>
+          </div>
+        </FieldGroup>
+      </Fieldset>
+    </form>
+  );
 }
 
 type PositionKey = "top" | "bottom" | "left" | "right";
 
 const positionStyles: { [key in PositionKey]: string } = {
-    top: "bottom-[calc(100%+0.5rem)] left-[38%] -translate-x-[50%]",
-    bottom: "top-[calc(100%+0.5rem)] left-[38%] -translate-x-[50%]",
-    left: "right-[calc(100%+0.5rem)] top-[38%] -translate-y-[50%]",
-    right: "left-[calc(100%+0.5rem)] top-[38%] -translate-y-[50%]",
+  top: "bottom-[calc(100%+0.5rem)] left-[38%] -translate-x-[50%]",
+  bottom: "top-[calc(100%+0.5rem)] left-[38%] -translate-x-[50%]",
+  left: "right-[calc(100%+0.5rem)] top-[38%] -translate-y-[50%]",
+  right: "left-[calc(100%+0.5rem)] top-[38%] -translate-y-[50%]",
 };
 
 const positionSVGs: { [key in PositionKey]: JSX.Element } = {
-    top: <svg className="absolute left-0 top-full h-2 w-full text-black" x="0px" y="0px" viewBox="0 0 255 255"><polygon className="fill-current" points="0,0 127.5,127.5 255,0" /></svg>,
-    bottom: <svg className="absolute left-0 bottom-full h-2 w-full text-black" x="0px" y="0px" viewBox="0 0 255 255"><polygon className="fill-current" points="0,0 127.5,127.5 255,0" /></svg>,
-    left: <svg className="absolute left-full top-0 h-full w-2 text-black" x="0px" y="0px" viewBox="0 0 255 255"><polygon className="fill-current" points="0,0 127.5,127.5 0,255" /></svg>,
-    right: <svg className="absolute right-full top-0 h-full w-2 text-black" x="0px" y="0px" viewBox="0 0 255 255"><polygon className="fill-current" points="255,0 0,127.5 255,255" /></svg>,
+  top: (
+    <svg
+      className="absolute left-0 top-full h-2 w-full text-black"
+      x="0px"
+      y="0px"
+      viewBox="0 0 255 255"
+    >
+      <polygon className="fill-current" points="0,0 127.5,127.5 255,0" />
+    </svg>
+  ),
+  bottom: (
+    <svg
+      className="absolute bottom-full left-0 h-2 w-full text-black"
+      x="0px"
+      y="0px"
+      viewBox="0 0 255 255"
+    >
+      <polygon className="fill-current" points="0,0 127.5,127.5 255,0" />
+    </svg>
+  ),
+  left: (
+    <svg
+      className="absolute left-full top-0 h-full w-2 text-black"
+      x="0px"
+      y="0px"
+      viewBox="0 0 255 255"
+    >
+      <polygon className="fill-current" points="0,0 127.5,127.5 0,255" />
+    </svg>
+  ),
+  right: (
+    <svg
+      className="absolute right-full top-0 h-full w-2 text-black"
+      x="0px"
+      y="0px"
+      viewBox="0 0 255 255"
+    >
+      <polygon className="fill-current" points="255,0 0,127.5 255,255" />
+    </svg>
+  ),
 };
 
-function Tooltip({ children, text, position }: { children: React.ReactNode, text: string, position: PositionKey }) {
-    const [showTooltip, setShowTooltip] = useState(false);
+function Tooltip({
+  children,
+  text,
+  position,
+}: {
+  children: React.ReactNode;
+  text: string;
+  position: PositionKey;
+}) {
+  const [showTooltip, setShowTooltip] = useState(false);
 
-    return (
-        <div className="group relative" onMouseEnter={() => setShowTooltip(true)} onMouseLeave={() => setShowTooltip(false)}>
-            <div className={`z-30 absolute ${positionStyles[position]} hidden group-hover:block w-auto transition ease-in-out duration-300 ${!showTooltip ? "hidden opacity-0" : "opacity-100"}`}>
-                <div className="bottom-full right-0 rounded bg-black px-4 py-1 text-xs text-white whitespace-nowrap">
-                    {text}
-                    {positionSVGs[position]}
-                </div>
-            </div>
-            {children}
+  return (
+    <div
+      className="group relative"
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+    >
+      <div
+        className={`absolute z-30 ${positionStyles[position]} hidden w-auto transition duration-300 ease-in-out group-hover:block ${!showTooltip ? "hidden opacity-0" : "opacity-100"}`}
+      >
+        <div className="bottom-full right-0 whitespace-nowrap rounded bg-black px-4 py-1 text-xs text-white">
+          {text}
+          {positionSVGs[position]}
         </div>
-    )
+      </div>
+      {children}
+    </div>
+  );
 }
 
 export default Records;

--- a/ts/atproto-tools/src/components/records-temp/Records.tsx
+++ b/ts/atproto-tools/src/components/records-temp/Records.tsx
@@ -113,11 +113,10 @@ const Records: FC = () => {
 
   return (
     <div className="flex min-h-0 min-w-0 grow flex-col gap-6 p-4 pt-6 lg:h-dvh lg:flex-row">
-      <div
-        className="flex min-h-0 grow flex-col gap-2 lg:basis-0"
-        style={{ colorScheme: "dark" }}
-      >
-        <h1 className="text-4xl font-bold">View Firehose Records</h1>
+      <div className="flex min-h-0 grow flex-col gap-2 lg:basis-0 dark:[color-scheme:dark]">
+        <h1 className="text-center text-4xl font-bold">
+          View Firehose Records
+        </h1>
         {queryInitialized && (
           <SearchForm
             didQuery={didQuery}
@@ -211,8 +210,9 @@ function RecordsTable({
             key={record?.key || ""}
             id={record?.key || ""}
             className={
-              (selectedRecord?.key === record?.key ? "!bg-white/[15%] " : "") +
-              " scroll-m-36"
+              (selectedRecord?.key === record?.key
+                ? "!bg-zinc-950/[15%] dark:!bg-white/[15%] "
+                : "") + " scroll-m-36"
             }
             onClick={() => setSelectedRecord(record)}
           >

--- a/ts/atproto-tools/src/components/records-temp/Records.tsx
+++ b/ts/atproto-tools/src/components/records-temp/Records.tsx
@@ -9,10 +9,11 @@ import { Field, FieldGroup, Fieldset, Label } from "../catalyst/fieldset";
 import { Input } from "../catalyst/input";
 
 
-const Records: FC<{}> = () => {
+const Records: FC = () => {
     const [selectedRecord, setSelectedRecord] = useState<JSONRecord | null>(null);
     const [records, setRecords] = useState<JSONRecord[]>([]);
     const [error, setError] = useState<string | null>(null);
+    const [hasFetched, setHasFetched] = useState(false);
 
     const [didQuery, setDIDQuery] = useState<string | null>(null);
     const [collectionQuery, setCollectionQuery] = useState<string | null>(null);
@@ -61,7 +62,8 @@ const Records: FC<{}> = () => {
                     setRecords(newRecords);
                     setSelectedRecord(firstRecord);
                 }
-            });
+            })
+            .finally(() => setHasFetched(true));
     };
 
     useEffect(() => {
@@ -110,7 +112,7 @@ const Records: FC<{}> = () => {
                     <RecordsTable records={records} setSelectedRecord={setSelectedRecord} selectedRecord={selectedRecord} />
                 </div>
             </div>
-            <RawRecord record={selectedRecord!} />
+            <RawRecord record={selectedRecord!} key={hasFetched ? "a" : "b"} />
         </div>
     )
 };


### PR DESCRIPTION
Before

<img width="1511" alt="Screenshot 2024-02-29 at 11 56 09" src="https://github.com/ericvolp12/atproto.tools/assets/10959775/79f761ce-1b1f-4282-93dd-3dad482bd367">

After

<img width="1511" alt="Screenshot 2024-02-29 at 12 31 04" src="https://github.com/ericvolp12/atproto.tools/assets/10959775/ea91ccb0-8d79-409c-a0e4-60b1aaa0b14d">

~~Still to fix - AT URI in the top left causes scrollbars to appear when it wraps on smaller screens~~

Weirdly enough, seems like things act differently on the initial layout vs if you resize the screen to trigger another layout. I simply force a rerender of `RawRecord` after the data is fetched so that it fixes the mysterious overflow. Probably the monoco editor not responding to layout changes properly?

PS apologies for the formatting changes - made a separate PR for code formatting via prettier to avoid this in future
