### PR TITLE
Add support for tid in the string type's format property

### DIFF
--- a/ts/atproto-tools/package.json
+++ b/ts/atproto-tools/package.json
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@atproto/lexicon": "^0.3.1",
+    "@atproto/lexicon": "^0.5.1",
     "@atproto/syntax": "^0.2.0",
     "@headlessui/react": "2.0.0-alpha.4",
     "@heroicons/react": "^2.1.1",
@@ -24,8 +24,8 @@
     "react-query": "^3.39.3",
     "react-responsive": "^9.0.2",
     "react-router-dom": "^6.22.1",
-    "zod": "^3.22.4",
-    "zod-to-json-schema": "^3.22.4"
+    "zod": "^3.23.8",
+    "zod-to-json-schema": "^3.23.5"
   },
   "devDependencies": {
     "@atproto/lex-cli": "^0.3.0",

--- a/ts/atproto-tools/pnpm-lock.yaml
+++ b/ts/atproto-tools/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@atproto/lexicon':
-    specifier: ^0.3.1
-    version: 0.3.1
+    specifier: ^0.5.1
+    version: 0.5.1
   '@atproto/syntax':
     specifier: ^0.2.0
     version: 0.2.0
@@ -42,11 +42,11 @@ dependencies:
     specifier: ^6.22.1
     version: 6.22.1(react-dom@18.2.0)(react@18.2.0)
   zod:
-    specifier: ^3.22.4
-    version: 3.22.4
+    specifier: ^3.23.8
+    version: 3.23.8
   zod-to-json-schema:
-    specifier: ^3.22.4
-    version: 3.22.4(zod@3.22.4)
+    specifier: ^3.23.5
+    version: 3.23.5(zod@3.23.8)
 
 devDependencies:
   '@atproto/lex-cli':
@@ -127,39 +127,80 @@ packages:
       graphemer: 1.4.0
       multiformats: 9.9.0
       uint8arrays: 3.0.0
-      zod: 3.22.4
+      zod: 3.23.8
+    dev: false
+
+  /@atproto/common-web@0.2.4:
+    resolution: {integrity: sha512-6+DOhQcTklFmeiSkZRx6iFeqi4OFtGl4yEDGATk00q4tEcPoPvyOBtYHN6+G9lrfJIfx5RfmggamvXlJv1PxxA==}
+    dependencies:
+      graphemer: 1.4.0
+      multiformats: 9.9.0
+      uint8arrays: 3.0.0
+      zod: 3.23.8
+    dev: true
+
+  /@atproto/common-web@0.4.3:
+    resolution: {integrity: sha512-nRDINmSe4VycJzPo6fP/hEltBcULFxt9Kw7fQk6405FyAWZiTluYHlXOnU7GkQfeUK44OENG1qFTBcmCJ7e8pg==}
+    dependencies:
+      graphemer: 1.4.0
+      multiformats: 9.9.0
+      uint8arrays: 3.0.0
+      zod: 3.23.8
+    dev: false
 
   /@atproto/lex-cli@0.3.0:
     resolution: {integrity: sha512-Jf0MTMQBbZ4zEOudeGbHFlXQ9YW5UKXHS6aDw82AiA++1xiKclV9JCJ5hh9/VHB0rAy9+PKMnlnv6cDcQ1G/4g==}
     hasBin: true
     dependencies:
-      '@atproto/lexicon': 0.3.1
+      '@atproto/lexicon': 0.3.3
       '@atproto/syntax': 0.1.5
-      chalk: 5.3.0
+      chalk: 5.6.2
       commander: 9.5.0
       ts-morph: 16.0.0
       yesno: 0.4.0
-      zod: 3.22.4
+      zod: 3.23.8
     dev: true
 
-  /@atproto/lexicon@0.3.1:
-    resolution: {integrity: sha512-yLy6GUNP4pn0mGUIyUHvN0UeBza0S03AgjTXVR6KliC4ut2+7SjNMe4cI4G1M8/bJMaccC6ooQSm2kvwiOdr3A==}
+  /@atproto/lexicon@0.3.3:
+    resolution: {integrity: sha512-6FOjdc3V05JKrtkhjfhHMS7f/4hMJOeHNtoE3Na7iFMpzBz0Lw5sw8kIFKY8pc8IG79qGcFgELyHLsljZYX+5A==}
     dependencies:
-      '@atproto/common-web': 0.2.3
-      '@atproto/syntax': 0.1.5
+      '@atproto/common-web': 0.2.4
+      '@atproto/syntax': 0.2.1
       iso-datestring-validator: 2.2.2
       multiformats: 9.9.0
-      zod: 3.22.4
+      zod: 3.23.8
+    dev: true
+
+  /@atproto/lexicon@0.5.1:
+    resolution: {integrity: sha512-y8AEtYmfgVl4fqFxqXAeGvhesiGkxiy3CWoJIfsFDDdTlZUC8DFnZrYhcqkIop3OlCkkljvpSJi1hbeC1tbi8A==}
+    dependencies:
+      '@atproto/common-web': 0.4.3
+      '@atproto/syntax': 0.4.1
+      iso-datestring-validator: 2.2.2
+      multiformats: 9.9.0
+      zod: 3.23.8
+    dev: false
 
   /@atproto/syntax@0.1.5:
     resolution: {integrity: sha512-pbY5lOnThoAbsmrdbN9LC/dNmckfqODJiX9zjW2t3BIHYFeGBc6w9bK3Vre8A0Hg8yWkQpv6gaBLu+ykgi2DJQ==}
     dependencies:
-      '@atproto/common-web': 0.2.3
+      '@atproto/common-web': 0.2.4
+    dev: true
 
   /@atproto/syntax@0.2.0:
     resolution: {integrity: sha512-K+9jl6mtxC9ytlR7msSiP9jVNqtdxEBSt0kOfsC924lqGwuD8nlUAMi1GSMgAZJGg/Rd+0MKXh789heTdeL3HQ==}
     dependencies:
       '@atproto/common-web': 0.2.3
+    dev: false
+
+  /@atproto/syntax@0.2.1:
+    resolution: {integrity: sha512-ImOuiICtB5h78j90hAYOfTYzr5q5Wut0irNdELiogA3i74a8EXThe+j6Tj8snanYggrShbu5c6BDc1tVj477Yw==}
+    dependencies:
+      '@atproto/common-web': 0.2.4
+    dev: true
+
+  /@atproto/syntax@0.4.1:
+    resolution: {integrity: sha512-CJdImtLAiFO+0z3BWTtxwk6aY5w4t8orHTMVJgkf++QRJWTxPbIFko/0hrkADB7n2EruDxDSeAgfUGehpH6ngw==}
     dev: false
 
   /@babel/code-frame@7.23.5:
@@ -1550,8 +1591,8 @@ packages:
       supports-color: 7.2.0
     dev: true
 
-  /chalk@5.3.0:
-    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
+  /chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
     dev: true
 
@@ -3095,13 +3136,13 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /zod-to-json-schema@3.22.4(zod@3.22.4):
-    resolution: {integrity: sha512-2Ed5dJ+n/O3cU383xSY28cuVi0BCQhF8nYqWU5paEpl7fVdqdAmiLdqLyfblbNdfOFwFfi/mqU4O1pwc60iBhQ==}
+  /zod-to-json-schema@3.23.5(zod@3.23.8):
+    resolution: {integrity: sha512-5wlSS0bXfF/BrL4jPAbz9da5hDlDptdEppYfe+x4eIJ7jioqKG9uUxOwPzqof09u/XeVdrgFu29lZi+8XNDJtA==}
     peerDependencies:
-      zod: ^3.22.4
+      zod: ^3.23.3
     dependencies:
-      zod: 3.22.4
+      zod: 3.23.8
     dev: false
 
-  /zod@3.22.4:
-    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+  /zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}


### PR DESCRIPTION
Add support for tid in the string type's format property as introduced in atproto/lexicon@0.4.1. 

Before: the schema did not recognize "tid" as a valid string format.
<img width="294" height="83" alt="image" src="https://github.com/user-attachments/assets/35abec09-bbda-490a-9096-c9764eca3b73" />
After: the schema accepts "tid" as a valid string format.
<img width="230" height="76" alt="image" src="https://github.com/user-attachments/assets/fbc49be7-6147-4222-b552-e723f32f17fa" />
